### PR TITLE
Render main table 4x times faster

### DIFF
--- a/src/components/table/row.tsx
+++ b/src/components/table/row.tsx
@@ -98,7 +98,7 @@ export default function Row(props: { adminControls: boolean, row: TLockup, token
 
   return (
     <>
-      <TableRow className={open ? 'expanded exp-row' : 'exp-row'} sx={{ '& > *': { borderBottom: 'unset' } }}>
+      <TableRow className={open ? 'expanded exp-row' : 'exp-row'}>
         <TableCell>
           <IconButton
             aria-label="expand row"
@@ -182,32 +182,34 @@ export default function Row(props: { adminControls: boolean, row: TLockup, token
           </Tooltip>
         </TableCell>
       </TableRow>
-      <TableRow className="expanded">
-        <TableCell style={{ padding: 0 }} colSpan={8}>
-          <Collapse in={open} timeout="auto" unmountOnExit>
-            <div className="lockup-row">
-              <ScheduleTable schedule={row.schedule} title="Lockup schedule" token={token} />
-              {vestingSchedule && (
-              <ScheduleTable schedule={vestingSchedule} title="Vesting schedule" token={token} />
-              )}
-
-              <div className="lockup-row-column chart">
-                <div style={{ height: 300 }}>
-                  <Chart data={chartData([row], token.decimals)} />
-                </div>
-
-                {adminControls && (
-                <div className="terminate">
-                  <span className="fine-print">{payerMessage}</span>
-                  {terminatorId && terminateButton(terminatorId)}
-
-                </div>
+      { open && (
+        <TableRow className="expanded">
+          <TableCell style={{ padding: 0 }} colSpan={8}>
+            <Collapse in={open} timeout="auto" unmountOnExit>
+              <div className="lockup-row">
+                <ScheduleTable schedule={row.schedule} title="Lockup schedule" token={token} />
+                {vestingSchedule && (
+                <ScheduleTable schedule={vestingSchedule} title="Vesting schedule" token={token} />
                 )}
+
+                <div className="lockup-row-column chart">
+                  <div style={{ height: 300 }}>
+                    <Chart data={chartData([row], token.decimals)} />
+                  </div>
+
+                  {adminControls && (
+                  <div className="terminate">
+                    <span className="fine-print">{payerMessage}</span>
+                    {terminatorId && terminateButton(terminatorId)}
+
+                  </div>
+                  )}
+                </div>
               </div>
-            </div>
-          </Collapse>
-        </TableCell>
-      </TableRow>
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -340,6 +340,10 @@ table.MuiTable-root.main-table tbody tr:first-child td {
   /* border-bottom: 1px solid var(--light-gray); */
 }
 
+table.MuiTable-root.main-table tbody tr td {
+  border-bottom: 1px solid #EAEDF7 !important;
+}
+
 table.MuiTable-root.main-table tbody tr:first-child td:first-child {
   /* border: 1px solid red; */
   border-top-left-radius: 10px;
@@ -356,16 +360,6 @@ table.MuiTable-root.main-table tbody tr:last-child td:first-child {
 }
 
 table.MuiTable-root.main-table tbody tr:last-child td:last-child {
-  /* border: 1px solid red; */
-  border-bottom-right-radius: 10px;
-}
-
-table.MuiTable-root.main-table tbody tr.exp-row:not(.expanded):nth-last-child(2) td:first-child {
-  /* border: 1px solid red; */
-  border-bottom-left-radius: 10px;
-}
-
-table.MuiTable-root.main-table tbody tr.exp-row:not(.expanded):nth-last-child(2) td:last-child {
   /* border: 1px solid red; */
   border-bottom-right-radius: 10px;
 }


### PR DESCRIPTION
BEFORE:
<img width="1680" alt="Screen Shot 2022-08-01 at 4 05 17 PM" src="https://user-images.githubusercontent.com/97043024/182161439-52edf6c1-efb0-4c36-8476-f5825f0e54a5.png">
<img width="798" alt="Screen Shot 2022-08-01 at 5 49 45 PM" src="https://user-images.githubusercontent.com/97043024/182162920-9faf2276-9cf1-4649-8a66-e677b26fd1c2.png">


AFTER:
<img width="1680" alt="Screen Shot 2022-08-01 at 5 44 07 PM" src="https://user-images.githubusercontent.com/97043024/182161558-b7de6341-6e54-4d44-a5c6-75786e24451d.png">
<img width="767" alt="Screen Shot 2022-08-01 at 5 50 16 PM" src="https://user-images.githubusercontent.com/97043024/182162936-4c211639-2b12-4b4f-ae61-099f722c5356.png">

